### PR TITLE
correct LICENSE for bundled works

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -200,3 +200,36 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
+----
+Additional components
+
+This software comes with additional components that carry terms independent of the primary code base.
+
+=JQuery
+
+This product contains portions of the jQuery JavaScript Library v1.11.3, including Swizzle.js.
+
+Copyright 2005, 2014 jQuery Foundation, Inc. and other contributors
+
+Distributed under the MIT license:
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For more information see http://jquery.com/ and http://sizzlejs.com/


### PR DESCRIPTION
repo contains two bundled works:
- diff-match-patch (ASLv2 with no NOTICE file)
- jquery (MIT)

the first doesn't require anything other than the header that's already present on the file. the second should cause an update to the LICENSE file that explains the terms it's included under (since they are not ASLv2).
